### PR TITLE
Fix the usage in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     name: Send a Message
     runs-on: ubuntu-latest
     steps:
-      - uses: zrosenbauer/slacker-action@main
+      - uses: zrosenbauer/slacker@main
         with:
           username: 'ExampleBot'
           icon_emoji: ':robot_face:'


### PR DESCRIPTION
Looks like it should be the name of the repository?
Also as a side note, I am here because our uses of the action were broken:
```
Error: Unable to resolve action. Repository not found: zrosenbauer/slacktion
```